### PR TITLE
Config fixups

### DIFF
--- a/metadataclient/mds.py
+++ b/metadataclient/mds.py
@@ -18,13 +18,19 @@ class MDSRO:
         self._RUN_START_CACHE = {}
         self._RUNSTOP_CACHE = {}
         self._DESCRIPTOR_CACHE = {}
-        self.config = self._verify_cfg(config)
+        self.config = config
 
-    def _verify_cfg(self, config):
-        config['host']
-        config['port']
-        config['timezone']
-        return config
+    @property
+    def config(self):
+        return self._config
+
+    @config.setter
+    def config(self, config):
+        for key in ['host', 'port', 'timezone']:
+            if key not in config:
+                raise KeyError("The key {!r} is missing from the "
+                               "configuration.".format(key))
+        self._config = config
 
     @property
     def _server_path(self):

--- a/metadataclient/mds.py
+++ b/metadataclient/mds.py
@@ -131,9 +131,6 @@ class MDSRO:
         self._RUNSTOP_CACHE.clear()
         self._DESCRIPTOR_CACHE.clear()
 
-    def reset_connection(self):
-        self.config.clear()
-
     def queryfactory(self, query, signature):
         """
         Currently only returns a simple dict mdservice expects.


### PR DESCRIPTION
Since there is not stateful connection in this implementation `reset_connection` does not seem to apply. As written, it actually cleared the config dict. Probably just a mistake?

Also, refactored `_verify_cfg` to be a setter/getter to that any updates to `config` are also verified.